### PR TITLE
Fix sweep fetching

### DIFF
--- a/matterport-dl.py
+++ b/matterport-dl.py
@@ -60,6 +60,7 @@ def downloadSweeps(accessurl, sweeps):
     with tqdm(total=(len(sweeps)*len(getVariants()))) as pbar:
         with concurrent.futures.ThreadPoolExecutor(max_workers=32) as executor:
             for sweep in sweeps:
+                sweep = sweep.replace("-", "")
                 for variant in getVariants():
                     pbar.update(1)
                     executor.submit(downloadFile, accessurl.format(filename=f'tiles/{sweep}/{variant}') + "&imageopt=1", f'tiles/{sweep}/{variant}')
@@ -263,7 +264,7 @@ def drange(x, y, jump):
 KNOWN_ACCESS_KEY=None
 def GetOrReplaceKey(url, is_read_key):
     global KNOWN_ACCESS_KEY
-    key_regex = r'(t=2\-.+?\-0)'
+    key_regex = r'(t=2\-.+?\-[0-9])(&|$|")'
     match = re.search(key_regex,url)
     if match is None:
         return url


### PR DESCRIPTION
Removes dashes from sweep names and makes the key regex more broad, so that more valid patterns are detected. This allows sweeps to be properly fetched again